### PR TITLE
Make isSolo() ignore npc attackers.

### DIFF
--- a/cron/3.queueProcess.php
+++ b/cron/3.queueProcess.php
@@ -265,10 +265,22 @@ function isSolo($row)
 {
     $notSolo = [29, 31, 237];
 
-    if ($row['attackerCount'] > 1) {
+    $numNPC = 0;
+    foreach ($row['involved'] as $key => $involved) {
+        if (!isset($involved['corporationID'])) {
+            $numNPC = $numNPC + 1;
+        } else {
+            if ($involved['corporationID'] < 1999999) {
+                $numNPC = $numNPC + 1;
+            }
+        }
+    }
+    
+    // Special case where all but one attackers are NPCs, e.g. fights at fw plexes and belts.
+    if ($row['attackerCount'] > $numNPC + 1) {
         return false;
     }
-
+    
     // make sure the victim isn't a pod, shuttle, or noobship
     $vGroupID = $row['vGroupID'];
 


### PR DESCRIPTION
RIght now clicking "Solo" on zkillboard won't show fights where all but one attackers are NPCs, which is probably most fights at fw plexes and some at belts.

I'm reusing same constant to check if corporationID is npc (sql dump tells that they're in range 1000002 - 1000274 right now but I couldn't find anything in official docs).